### PR TITLE
Fixed bug in get_trajectory function. The function would…

### DIFF
--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -168,9 +168,12 @@ class Trough:
             times (Optional[np.ndarray]): if ``None``, default to the
                 times of the observed solar insolation
         """
-        times = times or self.ins_times
-        x = self.get_xt(times)
-        y = self.get_yt(times)
+        if np.all(times) == None:
+            x = self.get_xt(self.ins_times)
+            y = self.get_yt(self.ins_times)
+        else:
+            x = self.get_xt(times)
+            y = self.get_yt(times)
         return x, y
 
     @staticmethod

--- a/test/test_trough.py
+++ b/test/test_trough.py
@@ -27,6 +27,19 @@ class TroughTest(TestCase):
         tr = self.get_trough_object()
         assert tr is not None
 
+    def test_get_trajectory(self):
+        tr = self.get_trough_object()
+        x, y = tr.get_trajectory()
+        assert len(x) == len(y)
+        assert len(x) == len(tr.ins_times)
+
+    def test_get_trajectory_input_times(self):
+        tr = self.get_trough_object()
+        times = np.linspace(0, 100)
+        x, y = tr.get_trajectory(times)
+        assert len(x) == len(y)
+        assert len(x) == len(times)
+
     def test_angle(self):
         tr1 = self.get_trough_object(angle=2.9)
         tr2 = self.get_trough_object(angle=3.9)


### PR DESCRIPTION
… break if the input (times) was an array with more than one element. Now it works even if times has more than one element. If there is no input, then the behavior is the same as before: it defaults to using self.ins_times as input.