### PR TITLE
Model class

### DIFF
--- a/mars_troughs/lag_model.py
+++ b/mars_troughs/lag_model.py
@@ -33,8 +33,8 @@ class ConstantLag(LagModel):
         self.constant = constant
 
     @property
-    def parameters(self) -> Dict[str, float]:
-        return {"constant": self.constant}
+    def parameter_names(self) -> Dict[str, float]:
+        return ["constant"]
 
     def lag(self, time: np.ndarray) -> np.ndarray:
         """
@@ -62,8 +62,8 @@ class LinearLag(LagModel):
         self.slope = slope
 
     @property
-    def parameters(self) -> Dict[str, float]:
-        return {"intercept": self.intercept, "slope": self.slope}
+    def parameter_names(self) -> Dict[str, float]:
+        return ["intercept", "slope"]
 
     def lag(self, time: np.ndarray) -> np.ndarray:
         """

--- a/mars_troughs/model.py
+++ b/mars_troughs/model.py
@@ -3,15 +3,50 @@ General class for models.
 """
 
 from abc import ABC
-from typing import Dict
+from typing import Dict, List
+
+from dataclass import asdict, dataclass, field
 
 
+@dataclass
 class Model(ABC):
     """
     Abstract class for a model, which has a property called `parameters`
     that returns a dictionary of the parameters in this model.
     """
 
+    prefix: str = ""
+    sub_models: List["Model"] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        our_names = set(self.parameter_names)
+        for sub_model in self.sub_models:
+            their_names = set(sub_model.parameter_names)
+            duplicates = our_names.intersection(their_names)
+            assert not duplicates, f"duplicate parameter names {duplicates}"
+
+    @property
+    def paramter_names(self) -> List[str]:
+        return sorted(self.parameters.keys())
+
     @property
     def parameters(self) -> Dict[str, float]:
-        raise NotImplementedError
+        # Find parameters of sub_models
+        sub_pars = {}
+        for sub_model in self.sub_models:
+            sub_pars = {**sub_pars, **sub_model.parameters}
+
+        # Convert our attributes to a dict
+        our_pars = asdict(self)
+
+        # Remove the 'sub_models' key from our parameters list
+        _ = our_pars.pop("sub_models")
+
+        # Prepend our prefix
+        if self.prefix != "":
+            our_pars = {
+                f"{self.prefix}_" + key: value for key, value in our_pars.items()
+            }
+
+        # Bundle up our parameters and all sub model's parameters
+        return {**our_pars, **sub_pars}

--- a/mars_troughs/model.py
+++ b/mars_troughs/model.py
@@ -1,52 +1,126 @@
 """
-General class for models.
+Abstract class for all models.
 """
 
-from abc import ABC
-from typing import Dict, List
-
-from dataclass import asdict, dataclass, field
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
 
 
-@dataclass
 class Model(ABC):
     """
-    Abstract class for a model, which has a property called `parameters`
-    that returns a dictionary of the parameters in this model.
+    Abstract class for a model, which has methods to keep track of its
+    parameters and the parameters of sub-models.
+
+    Parameters of the model **must be attributes** that match the name
+    provided in the :meth:`parameter_names` property.
+
+    Args:
+      sub_models (Optional[List["Model"]]): models contained within this
+        model that serve their own purpose
     """
 
-    prefix: str = ""
-    sub_models: List["Model"] = field(default_factory=list)
+    def __init__(self, sub_models: Optional[List["Model"]] = None) -> None:
+        # Add sub_models as an attribute
+        self.sub_models = sub_models or []
 
-    def __post_init__(self) -> None:
+        # Check for duplicate names between here and the sub-models
         our_names = set(self.parameter_names)
         for sub_model in self.sub_models:
-            their_names = set(sub_model.parameter_names)
+            their_names = set(sub_model.all_parameter_names)
             duplicates = our_names.intersection(their_names)
             assert not duplicates, f"duplicate parameter names {duplicates}"
 
     @property
-    def paramter_names(self) -> List[str]:
-        return sorted(self.parameters.keys())
+    @abstractmethod
+    def parameter_names(self) -> List[str]:
+        """
+        Names of the parameters for **this** object sorted alphabetically.
+        This method **must** be implemented for all subclasses, and the names
+        must consist of the names of the attributes that contain the
+        parameters.
+
+        Example:
+
+        .. code-block:: python
+
+           class MyModel(Model):
+               a = 3
+
+               @property
+               def parameter_names(self):
+                   return ["a"]
+
+               ...
+
+        Returns:
+          names of parametes for **this** object
+        """
+        raise NotImplementedError
 
     @property
-    def parameters(self) -> Dict[str, float]:
+    def parameters(self) -> Dict[str, Any]:
+        """
+        The parameters for **this** object, but not any of its sub-models.
+        The parameters **must** be attributes of the object
+
+        Returns:
+          name/value pairs where values can be numbers or arrays of numbers
+        """
+        return {name: getattr(self, name) for name in self.parameter_names}
+
+    @parameters.setter
+    def parameters(self, params: Dict[str, Any]) -> None:
+        """
+        Set the parameters for this object and all sub-models.
+
+        Args:
+          params (Dict[str, Any]): new parameters
+        """
+        assert set(params.keys()) == set(self.parameter_names)
+        for key, value in params.items():
+            setattr(self, key, value)
+        return
+
+    @property
+    def all_parameter_names(self) -> List[str]:
+        """
+        Names of the parameters for this object and all sub-models.
+
+        Returns:
+          names of parametes for this object and all sub-models
+        """
+        return sorted(self.all_parameters.keys())
+
+    @property
+    def all_parameters(self) -> Dict[str, Any]:
+        """
+        The parameters for this model and all sub-models.
+
+        Returns:
+          key-value pairs for this model and all sub-models
+        """
         # Find parameters of sub_models
         sub_pars = {}
         for sub_model in self.sub_models:
-            sub_pars = {**sub_pars, **sub_model.parameters}
-
-        # Convert our attributes to a dict
-        our_pars = asdict(self)
-
-        # Remove the 'sub_models' key from our parameters list
-        _ = our_pars.pop("sub_models")
-
-        # Prepend our prefix
-        if self.prefix != "":
-            our_pars = {
-                f"{self.prefix}_" + key: value for key, value in our_pars.items()
-            }
+            sub_pars = {**sub_pars, **sub_model.all_parameters}
 
         # Bundle up our parameters and all sub model's parameters
-        return {**our_pars, **sub_pars}
+        return {**self.parameters, **sub_pars}
+
+    @all_parameters.setter
+    def all_parameters(self, params: Dict[str, Any]) -> None:
+        """
+        Setter for this model's parameters and all sub-models.
+
+        Args:
+          params (Dict[str, Any]): new parameters
+        """
+        # Update this model's parameters
+        self.parameters = {key: params[key] for key in self.parameter_names}
+
+        # Update sub model's parameters
+        for sub_model in self.sub_models:
+            sub_model.all_parameters = {
+                key: params[key] for key in sub_model.all_parameter_names
+            }
+        return

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,3 +1,7 @@
+"""
+Test of the ``Model`` class using dummies.
+"""
+
 from unittest import TestCase
 
 from mars_troughs import Model

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+
+from mars_troughs import Model
+
+
+class DummyModel(Model):
+    a: float = 1.0
+    b: float = 10.0
+    c: float = 20.0
+
+    @property
+    def parameter_names(self):
+        return ["a", "b", "c"]
+
+
+class OtherModel(Model):
+    x: float = 3.0
+    y: float = 4.0
+
+    @property
+    def parameter_names(self):
+        return ["x", "y"]
+
+
+class TestModel(TestCase):
+    def test_smoke(self):
+        model = DummyModel()
+        assert isinstance(model, Model)
+        assert model.parameter_names == ["a", "b", "c"]
+        assert model.sub_models == []
+        assert model.all_parameter_names == ["a", "b", "c"]
+        assert model.parameters == {"a": 1.0, "b": 10.0, "c": 20.0}
+        # test setting one parameter
+        model.a = 30.0
+        assert model.parameters == {"a": 30.0, "b": 10.0, "c": 20.0}
+        # Test setting all parameters
+        model.parameters = {"a": -1.0, "b": -10.0, "c": -20.0}
+        assert model.parameters == {"a": -1.0, "b": -10.0, "c": -20.0}
+
+    def test_with_submodel(self):
+        sub = OtherModel()
+        model = DummyModel(sub_models=[sub])
+        assert model.parameter_names == ["a", "b", "c"]
+        assert model.sub_models == [sub]
+        assert model.parameters == {"a": 1.0, "b": 10.0, "c": 20.0}
+        assert model.all_parameters == {
+            "a": 1.0,
+            "b": 10.0,
+            "c": 20.0,
+            "x": 3.0,
+            "y": 4.0,
+        }
+        model.parameters = {"a": -1.0, "b": -10.0, "c": -20.0}
+        assert model.all_parameters == {
+            "a": -1.0,
+            "b": -10.0,
+            "c": -20.0,
+            "x": 3.0,
+            "y": 4.0,
+        }
+        model.all_parameters = {
+            "a": -2.0,
+            "b": -20.0,
+            "c": -40.0,
+            "x": 33.0,
+            "y": 44.0,
+        }
+        assert model.all_parameters == {
+            "a": -2.0,
+            "b": -20.0,
+            "c": -40.0,
+            "x": 33.0,
+            "y": 44.0,
+        }
+        assert model.parameters == {"a": -2.0, "b": -20.0, "c": -40.0}
+        assert sub.parameters == {"x": 33.0, "y": 44.0}


### PR DESCRIPTION
This PR closes #18.

I ended up changing the proposal a lot from what I wrote there. The biggest missing functionality for now is support for "prefixing" to the parameter names automatically (e.g. a the word "lag_" getting prepended to all lag model parameters -- if this PR gets merged I'll make a new issue for that).

This PR implements the API for all subclasses of `Model`. The requirements for subclasses are:
- a parameter must be an **attribute** of the object (i.e. can be accessed with `some_model.a_name`
- the subclass must implement the `parameter_names` property, which gives names of the attributes that are parameters

For example, here is a linear model example (and can be used as a template for any linear models we implement):
```python
class LinearModel(Model):
    # values are arbitrary for this example
    slope = 1
    intercept: 4

    @property
    def parameter_names(self):
        return ["slope", "intercept"]

    # make the model evaluate something
    def eval(self, x):
        return self.slope * x + self.intercept
```

Here is an example of a sinusoidal model:
```python
class Sinusoid(Model):
    # Values are arbitrary
    A = 1.
    w = 2 * np.pi
    c = np.pi / 2

    @property
    def parameter_names(self):
        return ["A", "w", "c"]

    # Make the model evaluate something
    def foo(self, x):
        return self.A * np.sin(self.w * x + self.c)
```

Updating the parameters can **either** be done at the attribute level or by updating all parameters at once with a dictionary:
```python
sine = Sinusoid()
sine.A = 10.
sine.parameters = {"A": 10., "w": np.pi, "c": 4}
```

Finally, the `Model` class is designed so that we can **compose** models out of sub-models. For example:
```python
linear = LinearModel()
sine = Sinusoid(sub_models=[linear])

sine.all_parameter_names
# >>> ["A", "w", "c", "slope", "intercept"]
```