### PR TITLE
Sub models updated

### DIFF
--- a/mars_troughs/__init__.py
+++ b/mars_troughs/__init__.py
@@ -1,4 +1,4 @@
-from .accumulation_model import AccumulationModel, LinearInsolationAccumulation
+from .accumulation_model import AccumulationModel, LinearInsolationAccumulation, QuadraticInsolationAccumulation 
 from .datapaths import DATAPATHS
 from .lag_model import ConstantLag, LagModel, LinearLag
 from .model import Model

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -41,7 +41,7 @@ class InsolationAccumulationModel(AccumulationModel):
         self._int_ins2_data_spline = self._ins2_data_spline.antiderivative()
         
     def get_xt(self, time: np.ndarray, int_retreat_model_t_spline: np.ndarray, 
-                                                       angle: float = 2.9):  
+                                                       cot_angle,csc_angle):  
         """
         Calculates the horizontal distance x (in m) traveled by a point in the
         center of the high side of the trough. This distance x is a function of 
@@ -54,40 +54,12 @@ class InsolationAccumulationModel(AccumulationModel):
         Output:
             horizontal distances (np.ndarray) of the same size as time input, in
             meters.
-        """
-        self.angle=angle           
+        """          
         yt = self.get_yt(time)
         
-        return -self.cot_angle * yt + self.csc_angle * (
+        return -cot_angle * yt + csc_angle * (
                int_retreat_model_t_spline(time) - int_retreat_model_t_spline(0))
     
-    @property
-    def angle(self) -> float:
-        """
-        Slope angle in degrees.
-        """
-        return self._angle * 180.0 / np.pi
-
-    @angle.setter
-    def angle(self, value: float) -> float:
-        """Setter for the angle"""
-        self._angle = value * np.pi / 180.0
-        self._csc = 1.0 / np.sin(self._angle)
-        self._cot = np.cos(self._angle) * self._csc
-
-    @property
-    def csc_angle(self) -> float:
-        """
-        Cosecant of the slope angle.
-        """
-        return self._csc
-
-    @property
-    def cot_angle(self) -> float:
-        """
-        Cotangent of the slope angle.
-        """
-        return self._cot
 
 class LinearInsolationAccumulation(InsolationAccumulationModel):
     """

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -35,8 +35,8 @@ class InsolationAccumulationModel(AccumulationModel):
     def __init__(self, times: np.ndarray, insolations: np.ndarray):
         self._ins_times = times
         self._insolations = insolations
-        self._ins_spline = IUS(self._ins_times, self._insolations)
-        self._ins_spline_integ = self._ins_spline.antiderivative()
+        self._ins_data_spline = IUS(self._ins_times, self._insolations)
+        self._int_ins_data_spline = self._ins_spline.antiderivative()
         self._ins2_spline = IUS(self._ins_times, self._insolations ** 2)
         self._ins2_spline_integ = self.ins2_spline.antiderivative()
 
@@ -82,7 +82,7 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
             accumulation rates A in m/year
         
         """
-        return self.intercept +  (self.slope * self.ins_data_spline(time))
+        return self.intercept +  (self.slope * self._ins_data_spline(time))
     
     def get_yt(self, time: np.ndarray):
         """
@@ -98,5 +98,5 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
             the vertical distance y, in meters.
         
         """
-        return self.intercept -1 * (self.slope * (self.iins_data_spline(time) 
-                                                 - self.iins_data_spline(0)))
+        return self.intercept -1 *(self.slope * (self._int_ins_data_spline(time) 
+                                               - self._int_ins_data_spline(0)))

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -192,3 +192,23 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
         """
         return self.intercept + self.linearCoeff * self._ins_data_spline(time) \
                               + self.quadCoeff * self._ins2_data_spline(time)
+        
+    def get_yt(self, time: np.ndarray):
+        """
+        Calculates the vertical distance y (in m) at times t traveled by a point
+        in the center of the high side of the trough. This distance  is a 
+        function of the accumulation rate A as y(t)=int(A(ins(t)) dt) or 
+        dy/dt=A(ins(t))
+
+        Args:
+            time (np.ndarray): times at which we want to calculate y, in years.
+        Output:
+            np.ndarray of the same size as time input containing values of 
+            the vertical distance y, in meters.
+        
+        """
+        return self.intercept  + (
+               self.linearCoeff * (self._int_ins_data_spline(time) - 
+                              self._int_ins_data_spline(0))
+             + self.quadCoeff * (self._int_ins2_data_spline(time) - 
+                              self._int_ins2_data_spline(0)))

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -23,7 +23,7 @@ class AccumulationModel(Model):
 class InsolationAccumulationModel(AccumulationModel):
     """
     An accumulation rate model that depends on solar insolation, A(Ins(t)).
-    A in in m/year. Interpolated splines are created for the insolation as 
+    A is in m/year. Interpolated splines are created for the insolation as 
     a function of time for faster integration.
 
     Args:
@@ -45,7 +45,7 @@ class InsolationAccumulationModel(AccumulationModel):
         """
         Calculates the horizontal distance x (in m) traveled by a point in the
         center of the high side of the trough. This distance x is a function of 
-        the accumulation rate A and the retreat rate of ice R
+        the accumulation rate A(ins(t)) and the retreat rate of ice R(l(t),t)
         as in dx/dt=(R(l(t),t)+A(ins(t))cos(theta))/sin(theta). Where theta
         is the slope angle of the trough.
 
@@ -128,14 +128,14 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
             time (np.ndarray): times at which we want to calculate A, in years.
         Output:
             np.ndarray of the same size as time input containing values of 
-            accumulation rates A in m/year
+            accumulation rates A, in m/year
         
         """
         return self.intercept + self.slope * self._ins_data_spline(time)
     
     def get_yt(self, time: np.ndarray):
         """
-        Calculates the vertical distance y (in m) at times t traveled by a point
+        Calculates the vertical distance y (in m) traveled by a point
         in the center of the high side of the trough. This distance  is a 
         function of the accumulation rate A as y(t)=int(A(ins(t)), dt) or 
         dy/dt=A(ins(t))
@@ -160,13 +160,13 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
         times (np.ndarray): times at which the solar insolation is known, in
                             years.
         insolations (np.ndarray): value of the solar insolations (in W/m^2)
-        intercept (float, optional): default is 0 m/year
+        intercept (float, optional): default is 1 m/year
         linearCoeff (float, optional): default is 1e-6 m/year per unit
             of solar insolation (m^3/(year*W)).
         quadCoeff (float, optional): default is 1e-6 m/year per unit
             of solar insolation squared (m^5/(year*W^2)).
     """
-    def __init__(self, times, insolation, intercept: float = 0.0, 
+    def __init__(self, times, insolation, intercept: float = 1.0, 
                  linearCoeff: float = 1e-6, quadCoeff: float = 1e-6):
         
         super().__init__(times, insolation)
@@ -187,7 +187,7 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
             time (np.ndarray): times at which we want to calculate A, in years.
         Output:
             np.ndarray of the same size as time input containing values of 
-            accumulation rates A in m/year
+            accumulation rates A, in m/year
         
         """
         return self.intercept + self.linearCoeff * self._ins_data_spline(time) \
@@ -195,7 +195,7 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
         
     def get_yt(self, time: np.ndarray):
         """
-        Calculates the vertical distance y (in m) at times t traveled by a point
+        Calculates the vertical distance y (in m) at traveled by a point
         in the center of the high side of the trough. This distance  is a 
         function of the accumulation rate A as y(t)=int(A(ins(t)) dt) or 
         dy/dt=A(ins(t))

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -109,7 +109,7 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
         """
         Calculates the vertical distance y (in m) traveled by a point
         in the center of the high side of the trough. This distance  is a 
-        function of the accumulation rate A as y(t)=int(A(ins(t)), dt) or 
+        function of the accumulation rate A as y(t)=integral(A(ins(t)), dt) or 
         dy/dt=A(ins(t))
 
         Args:
@@ -169,7 +169,7 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
         """
         Calculates the vertical distance y (in m) at traveled by a point
         in the center of the high side of the trough. This distance  is a 
-        function of the accumulation rate A as y(t)=int(A(ins(t)) dt) or 
+        function of the accumulation rate A as y(t)=integral(A(ins(t)), dt) or 
         dy/dt=A(ins(t))
 
         Args:

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -36,10 +36,58 @@ class InsolationAccumulationModel(AccumulationModel):
         self._ins_times = times
         self._insolations = insolations
         self._ins_data_spline = IUS(self._ins_times, self._insolations)
-        self._int_ins_data_spline = self._ins_spline.antiderivative()
+        self._int_ins_data_spline = self._ins_data_spline.antiderivative()
         self._ins2_spline = IUS(self._ins_times, self._insolations ** 2)
-        self._ins2_spline_integ = self.ins2_spline.antiderivative()
+        self._ins2_spline_integ = self._ins2_spline.antiderivative()
+        
+    def get_xt(self, time: np.ndarray, int_retreat_model_t_spline: np.ndarray, 
+                                                       angle: float = 2.9):  
+        """
+        Calculates the horizontal distance x (in m) traveled by a point in the
+        center of the high side of the trough. This distance x is a function of 
+        the accumulation rate A and the retreat rate of ice R
+        as in dx/dt=(R(l(t),t)+A(ins(t))cos(theta))/sin(theta). Where theta
+        is the slope angle of the trough.
 
+        Args:
+            time (np.ndarray): times at which we want the path.
+        Output:
+            horizontal distances (np.ndarray) of the same size as time input, in
+            meters.
+        """
+        self.angle=angle           
+        yt = self.get_yt(time)
+        
+        return -self.cot_angle * yt + self.csc_angle * (
+               int_retreat_model_t_spline(time) - int_retreat_model_t_spline(0))
+    
+    @property
+    def angle(self) -> float:
+        """
+        Slope angle in degrees.
+        """
+        return self._angle * 180.0 / np.pi
+
+    @angle.setter
+    def angle(self, value: float) -> float:
+        """Setter for the angle"""
+        self._angle = value * np.pi / 180.0
+        self._csc = 1.0 / np.sin(self._angle)
+        self._cot = np.cos(self._angle) * self._csc
+
+    @property
+    def csc_angle(self) -> float:
+        """
+        Cosecant of the slope angle.
+        """
+        return self._csc
+
+    @property
+    def cot_angle(self) -> float:
+        """
+        Cotangent of the slope angle.
+        """
+        return self._cot
 
 class LinearInsolationAccumulation(InsolationAccumulationModel):
     """
@@ -62,14 +110,14 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
         insolations: np.ndarray,
         intercept: float = 1.0,
         slope: float = 1e-6,
-    ):
+        ):
         super().__init__(times, insolations)
         self.intercept = intercept
         self.slope = slope
 
     @property
-    def parameters(self) -> Dict[str, float]:
-        return {"intercept": self.intercept, "slope": self.slope}
+    def parameter_names(self) -> Dict[str, float]:
+        return ["intercept", "slope"]
 
     def get_accumulation_at_t(self, time: np.ndarray) -> np.ndarray:
         """
@@ -98,5 +146,7 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
             the vertical distance y, in meters.
         
         """
-        return self.intercept -1 *(self.slope * (self._int_ins_data_spline(time) 
-                                               - self._int_ins_data_spline(0)))
+        return  -1 *(self.slope * (self._int_ins_data_spline(time) 
+                                 - self._int_ins_data_spline(0)))
+    
+    

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -119,8 +119,8 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
             the vertical distance y, in meters.
         
         """
-        return  -1 *(self.slope * (self._int_ins_data_spline(time) 
-                                 - self._int_ins_data_spline(0)))
+        return  -(self.intercept*time + (self.slope *( 
+            self._int_ins_data_spline(time) - self._int_ins_data_spline(0))))
  
 class QuadraticInsolationAccumulation(InsolationAccumulationModel):
     """
@@ -179,8 +179,8 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
             the vertical distance y, in meters.
         
         """
-        return self.intercept  + (
+        return -(self.intercept*time  + (
                self.linearCoeff * (self._int_ins_data_spline(time) - 
                               self._int_ins_data_spline(0))
              + self.quadCoeff * (self._int_ins2_data_spline(time) - 
-                              self._int_ins2_data_spline(0)))
+                              self._int_ins2_data_spline(0))))

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -100,7 +100,7 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
                             (in years)
         insolation values (np.ndarray): values of solar insolation (in W/m^2)
         intercept (float, optional): accumulation rate at present time.
-                                     Default is 1 m/year
+                                     Default is 1e-6 m/year
         slope (float, optional): default is 1e-6 m/year per unit
                                  of solar insolation (m^3/(year*W)).
     """
@@ -109,7 +109,7 @@ class LinearInsolationAccumulation(InsolationAccumulationModel):
         self,
         times: np.ndarray,
         insolations: np.ndarray,
-        intercept: float = 1.0,
+        intercept: float = 1e-6,
         slope: float = 1e-6,
         ):
         super().__init__(times, insolations)

--- a/mars_troughs/lag_model.py
+++ b/mars_troughs/lag_model.py
@@ -11,18 +11,19 @@ from mars_troughs.model import Model
 
 class LagModel(Model):
     """
-    Abstract class for lag models, that have a method called :meth:`lag`
-    that returns the lag as a function of time.
+    Abstract class for lag models, that have a method 
+    called :meth:`get_lag_at_t` that returns the lag 
+    as a function of time.
     """
 
     @abstractmethod
-    def lag(self, time: np.ndarray) -> np.ndarray:
+    def get_lag_at_t(self, time: np.ndarray) -> np.ndarray:
         raise NotImplementedError
 
 
 class ConstantLag(LagModel):
     """
-    Constant lag model. The lag thickness does not depend on time at all.
+    The lag thickness is constant and does not depend on time.
 
     Args:
         constant (float, optional): default is 1 millimeter. The lag
@@ -36,25 +37,30 @@ class ConstantLag(LagModel):
     def parameter_names(self) -> Dict[str, float]:
         return ["constant"]
 
-    def lag(self, time: np.ndarray) -> np.ndarray:
+    def get_lag_at_t(self, time: np.ndarray) -> np.ndarray:
         """
-        Lag as a function of time. Always returns a constant.
+        Lag as a function of time: returns constant lag values.
 
         Args:
-            time (np.ndarray): ignored
+            time (np.ndarray): times at which we want to calculate the lag.
+        Output:
+            np.ndarray of the same size as time input containing values of lag. 
+            All elements in the array are the same since the lag is
+            constant.
         """
         return self.constant * np.ones_like(time)
 
 
 class LinearLag(LagModel):
     """
-    The lag thickness is linear in time.
+    The lag thickness is linear in time. Lag changes as 
+    lag(t) = intercept + slope*t.
 
     Args:
         intercept (float, optional): default is 1 millimeter. The lag
             thickness at time t=0 (present day).
         slope (float, optional): default is 1e-6 mm per year. The rate
-            of change of the lag each year.
+            of change of the lag per time.
     """
 
     def __init__(self, intercept: float = 1.0, slope: float = 1e-6):
@@ -65,11 +71,15 @@ class LinearLag(LagModel):
     def parameter_names(self) -> Dict[str, float]:
         return ["intercept", "slope"]
 
-    def lag(self, time: np.ndarray) -> np.ndarray:
+    def get_lag_at_t(self, time: np.ndarray) -> np.ndarray:
         """
-        Lag as a function of time.
+        Compute lag thickness at each value of time
 
         Args:
-            time (np.ndarray): times to evaluate the lag
+            time (np.ndarray): times at which we want to calculate the lag.
+        Output:
+            np.ndarray of the same size as time input containing values of lag
+            thickness. 
+        
         """
         return self.intercept + self.slope * time

--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -213,13 +213,15 @@ class Trough:
             x and y coordinates (tuple) of size 2 x len(times) (in m).
         """
         if np.all(times) is None:
-            times=self.times 
+            times=self.ins_times
             
         int_retreat_model_t_spline=self.int_retreat_model_t_spline
-        angle=self.angle
+        cot_angle=self.cot_angle
+        csc_angle=self.csc_angle
         
         y=self.accuModel.get_yt(times)
-        x=self.accuModel.get_xt(times,int_retreat_model_t_spline,angle)
+        x=self.accuModel.get_xt(times,int_retreat_model_t_spline,cot_angle,
+                                                                 csc_angle)
         
         return x,y
             
@@ -285,3 +287,31 @@ class Trough:
         xvar, yvar = (self.errorbar * self.meters_per_pixel) ** 2
         chi2 = (x_data - x_model) ** 2 / xvar + (y_data - y_model) ** 2 / yvar
         return -0.5 * chi2.sum() - 0.5 * len(x_data) * np.log(xvar * yvar)
+    
+    @property
+    def angle(self) -> float:
+        """
+        Slope angle in degrees.
+        """
+        return self._angle * 180.0 / np.pi
+
+    @angle.setter
+    def angle(self, value: float) -> float:
+        """Setter for the angle"""
+        self._angle = value * np.pi / 180.0
+        self._csc = 1.0 / np.sin(self._angle)
+        self._cot = np.cos(self._angle) * self._csc
+
+    @property
+    def csc_angle(self) -> float:
+        """
+        Cosecant of the slope angle.
+        """
+        return self._csc
+
+    @property
+    def cot_angle(self) -> float:
+        """
+        Cotangent of the slope angle.
+        """
+        return self._cot

--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -9,8 +9,10 @@ from scipy.interpolate import InterpolatedUnivariateSpline as IUS
 from scipy.interpolate import RectBivariateSpline as RBS
 
 from mars_troughs import DATAPATHS
+
 from mars_troughs import ConstantLag,LinearLag
-from mars_troughs import LinearInsolationAccumulation, QuadraticInsolationAccumulation
+from mars_troughs import LinearInsolationAccumulation
+from mars_troughs import QuadraticInsolationAccumulation
 
 class Trough:
     def __init__(
@@ -71,7 +73,19 @@ class Trough:
         self.ret_data_spline = RBS(self.lags, self.ins_times, self.retreats)
         self.re2_data_spline = RBS(self.lags, self.ins_times, self.retreats ** 2)
         
-        #Create lag model object        
+        # Create accumulation model object
+        if self.acc_model_number == 0: 
+            intercept,slope = self.acc_params[0:2]
+            self.accuModel=LinearInsolationAccumulation(self.ins_times,
+                                        self.insolation,intercept,slope)
+        elif self.acc_model_number == 1:
+            intercept,linearCoeff,quadCoeff=self.acc_params[0:3]
+            self.accuModel=QuadraticInsolationAccumulation(self.ins_times,
+                            self.insolation,intercept,linearCoeff,quadCoeff)
+        else:
+            print("Error: accumulation model number should be 0 or 1")
+        
+        # Create lag model object        
         if self.lag_model_number == 0: 
             constant = self.lag_params[0]
             self.lagModel=ConstantLag(constant)
@@ -81,7 +95,7 @@ class Trough:
         else:
             print("Error: lag model number should be 0 or 1")
             
-        #Calculate model of lag per time
+        # Calculate model of lag per time
         self.lag_model_t=self.lagModel.get_lag_at_t(self.ins_times)
         
         # Calculate the model of retreat of ice per time 
@@ -119,15 +133,20 @@ class Trough:
         # Set the new accumulation and lag parameters
         self.acc_params = acc_params
         self.lag_params = lag_params
+
+        # Update accumulation model object
+        ins_times=self.ins_times
+        insolation=self.insolation
         
-        # Update lag model
-        if self.lag_model_number == 0: 
-            constant = self.lag_params[0]
-            self.lagModel=ConstantLag(constant)
+        if self.acc_model_number == 0:
+            intercept,slope=self.acc_params[0:2]
+            self.accuModel=LinearInsolationAccumulation(ins_times,insolation,
+                                                        intercept,slope)
         else:
-            intersect,slope = self.lag_params[0:2]
-            self.lagModel=LinearLag(intersect,slope)
-            
+            intercept,linearCoeff,quadCoeff=self.acc_params[0:3]
+            self.accuModel=QuadraticInsolationAccumulation(ins_times,
+                                  insolation,intercept,linearCoeff,quadCoeff)
+        
         # Update the model of lag at all times
         self.lag_model_t=self.lagModel.get_lag_at_t(self.ins_times)
         
@@ -150,7 +169,7 @@ class Trough:
         self.lag_model_t_spline = IUS(self.ins_times, self.lag_model_t)
         # spline of retreat model of ice per time 
         self.retreat_model_t_spline = IUS(self.ins_times, self.retreat_model_t)
-        self.iretreat_model_t_spline = self.retreat_model_t_spline.antiderivative()
+        self.int_retreat_model_t_spline = self.retreat_model_t_spline.antiderivative()
         return
 
     def get_insolation(self, time):
@@ -182,76 +201,10 @@ class Trough:
         return self.ret_data_spline.ev(lag_t, time)
 
 
-    def get_accumulation(self, time):  # Model dependent
-        """
-        Calculates the values of accumulation (in m^3/W) per time.
-        If model number = 0, Acc(t) = a*I(t) where I(t) is insolation at t
-        If model number = 1, Acc(t) = a*I(t) + b*I(t)^2.
-        a and b are the elements of acc_params.
-
-        Args:
-            time (np.ndarray): times at which we want to calculate the Acc.
-        Output:
-            accumulation values (np.ndarray) of the same size as time input
-        """
-        num = self.acc_model_number
-        p = self.acc_params
-        if num == 0:
-            a = p[0]  # a*Ins(t)
-            return -1 * (a * self.ins_data_spline(time))
-        if num == 1:
-            a, b = p[0:2]  # a*Ins(t) + b*Ins(t)^2
-            return -1 * (a * self.ins_data_spline(time) + b * self.ins2_data_spline(time))
-        return  # error, since no number is returned
-
-    def get_yt(self, time: np.ndarray) -> np.ndarray:  # Model dependent
-        """
-        Calculates the vertical distance (in m) traveled by a point in the
-        center of the high side of the trough. The vertical distance is
-        calculated at each input time. This distance  is a function of the
-        accumulation rate parameter H, as in dy/dt=H.
-
-        Args:
-            time (np.ndarray): times at which we want to calculate the path.
-        Output:
-            vertical distances (np.ndarray) of the same size as time input.
-        """
-        num = self.acc_model_number
-        p = self.acc_params
-        if num == 0:
-            a = p[0]  # a*Ins(t)
-            return -1 * (a * (self.iins_data_spline(time) - self.iins_data_spline(0)))
-        if num == 1:
-            a, b = p[0:2]  # a*Ins(t) + b*Ins(t)^2
-            return -1 * (
-                a * (self.iins_data_spline(time) - self.iins_data_spline(0))
-                + b * (self.iins2_data_spline(time) - self.iins2_data_spline(0))
-            )
-        return  # error
-
-    def get_xt(self, time: np.ndarray) -> np.ndarray:  # Model dependent
-        """
-        Calculates the horizontal distance (in m) traveled by a point in the
-        center of the high side of the trough. The horizontal distance is
-        calculated at each input time. This distance is a function of the
-        accumulation rate parameter H and the retreat of ice R
-        as in dx/dt=(R+Hcos(slope))/sin(slope).
-
-        Args:
-            time (np.ndarray): times at which we want the path.
-        Output:
-            horizontal distances (np.ndarray) of the same size as time input.
-        """
-        yt = self.get_yt(time)
-        return -self.cot_angle * yt + self.csc_angle * (
-            self.iretreat_model_t_spline(time) - self.iretreat_model_t_spline(0)
-        )
-
     def get_trajectory(self, times: Optional[np.ndarray] = None):
         """
         Obtains the x and y coordinates (in m) of the trough model as a 
-        function of time by concatenating the outputs of get_xt() 
-        and get_yt().
+        function of time.
 
         Args:
             times (Optional[np.ndarray]): if ``None``, default to the
@@ -260,12 +213,16 @@ class Trough:
             x and y coordinates (tuple) of size 2 x len(times) (in m).
         """
         if np.all(times) is None:
-            x = self.get_xt(self.ins_times)
-            y = self.get_yt(self.ins_times)
-        else:
-            x = self.get_xt(times)
-            y = self.get_yt(times)
-        return x, y
+            times=self.times 
+            
+        int_retreat_model_t_spline=self.int_retreat_model_t_spline
+        angle=self.angle
+        
+        y=self.accuModel.get_yt(times)
+        x=self.accuModel.get_xt(times,int_retreat_model_t_spline,angle)
+        
+        return x,y
+            
 
     @staticmethod
     def _L2_distance(x1, x2, y1, y2) -> Union[float, np.ndarray]:
@@ -328,31 +285,3 @@ class Trough:
         xvar, yvar = (self.errorbar * self.meters_per_pixel) ** 2
         chi2 = (x_data - x_model) ** 2 / xvar + (y_data - y_model) ** 2 / yvar
         return -0.5 * chi2.sum() - 0.5 * len(x_data) * np.log(xvar * yvar)
-
-    @property
-    def angle(self) -> float:
-        """
-        Slope angle in degrees.
-        """
-        return self._angle * 180.0 / np.pi
-
-    @angle.setter
-    def angle(self, value: float) -> float:
-        """Setter for the angle"""
-        self._angle = value * np.pi / 180.0
-        self._csc = 1.0 / np.sin(self._angle)
-        self._cot = np.cos(self._angle) * self._csc
-
-    @property
-    def csc_angle(self) -> float:
-        """
-        Cosecant of the slope angle.
-        """
-        return self._csc
-
-    @property
-    def cot_angle(self) -> float:
-        """
-        Cotangent of the slope angle.
-        """
-        return self._cot

--- a/test/test_lag_model.py
+++ b/test/test_lag_model.py
@@ -26,7 +26,7 @@ class ConstantLagTest(TestCase):
         time = np.linspace(0, 1e6, 1000)
         for const in [1.0, 2.0, 2.5]:
             model = ConstantLag(const)
-            lags = model.lag(time)
+            lags = model.get_lag_at_t(time)
             assert (lags == np.ones_like(time) * const).all()
 
 
@@ -51,5 +51,5 @@ class LinearLagTest(TestCase):
             model = LinearLag(inter, slope)
             assert model.intercept == inter
             assert model.slope == slope
-            lags = model.lag(time)
+            lags = model.get_lag_at_t(time)
             assert (lags == inter + slope * time).all()

--- a/test/test_trough.py
+++ b/test/test_trough.py
@@ -7,7 +7,7 @@ from mars_troughs import Trough
 
 class TroughTest(TestCase):
     def setUp(self):
-        self.acc_params = [1e-6, 1e-11]
+        self.acc_params = [1e-6, 1e-11,1e-11]
         self.acc_model_number = 1
         self.lag_params = [1, 1e-7]
         self.lag_model_number = 1


### PR DESCRIPTION
DONE:
-Added dependency to abstract class "Model" in lag and accumulation submodels
-Included the parameter_names method in all submodels
-Moved the properties (@property) of the angle to the trough class from the accumulation class
-Modified how the trough class is linked to the submodels: now objects of the submodel classes are created and can be later modified in the setModel method.
-Modified the test files for the lag and accumulation models, nothing major, just changes in names of objects 
-Accumulation model 0 now requires 2 parameters: intercept and slope. 
-Accumulation model 1 now requires 3 parameters: intercept, linearCoeff and quadCoeff.

PENDING:
-acc_params and lag_params of the trough class are still positional and not dictionaries.
