### PR TITLE
Dictionaries

### DIFF
--- a/mars_troughs/__init__.py
+++ b/mars_troughs/__init__.py
@@ -2,9 +2,10 @@ from .accumulation_model import (
     AccumulationModel,
     LinearInsolationAccumulation,
     QuadraticInsolationAccumulation,
+    ACCUMULATION_MODEL_MAP,
 )
 from .datapaths import DATAPATHS
-from .lag_model import ConstantLag, LagModel, LinearLag
+from .lag_model import ConstantLag, LagModel, LinearLag, LAG_MODEL_MAP
 from .model import Model
 from .trough import Trough
 

--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -10,6 +10,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline as IUS
 from mars_troughs.model import Model
 
 
+
 class AccumulationModel(Model):
     """
     Abstract class for computing the amount of ice accumulation.
@@ -213,3 +214,8 @@ class QuadraticInsolationAccumulation(InsolationAccumulationModel):
                 )
             )
         )
+
+ACCUMULATION_MODEL_MAP: Dict[str, Model] = {
+    "linear": LinearInsolationAccumulation,
+    "quadratic": QuadraticInsolationAccumulation,
+}

--- a/mars_troughs/lag_model.py
+++ b/mars_troughs/lag_model.py
@@ -83,3 +83,8 @@ class LinearLag(LagModel):
 
         """
         return self.intercept + self.slope * time
+
+LAG_MODEL_MAP: Dict[str, Model] = {
+    "constant": ConstantLag,
+    "linear": LinearLag,
+}

--- a/test/test_trough.py
+++ b/test/test_trough.py
@@ -8,17 +8,17 @@ from mars_troughs import Trough
 class TroughTest(TestCase):
     def setUp(self):
         self.acc_params = [1e-6, 1e-11, 1e-11]
-        self.acc_model_number = 1
+        self.acc_model_name = 'quadratic'
         self.lag_params = [1, 1e-7]
-        self.lag_model_number = 1
+        self.lag_model_name = 'linear'
         self.errorbar = 100.0
 
     def get_trough_object(self, **kwargs):
         return Trough(
             self.acc_params,
             self.lag_params,
-            self.acc_model_number,
-            self.lag_model_number,
+            self.acc_model_name,
+            self.lag_model_name,
             self.errorbar,
             **kwargs,
         )


### PR DESCRIPTION
Updated trough object so it takes acc and lag model names (strings) instead of numbers. This closes issue # 28.