### PR TITLE
Trough cleanup

### DIFF
--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -95,6 +95,7 @@ class Trough:
         """
         Updates trough model with new accumulation and lag parameters.
         Model number is kept the same for both acumulation and lag.
+
         Args:
             acc_params (list): Accumulation parameter(s) (same length
                                      as current acumulation parameter(s)).
@@ -124,6 +125,7 @@ class Trough:
         """
         Computes splines of models of 1) lag per time and
         2) retreat of ice per time.
+
         Args:
             None
         Output:
@@ -143,6 +145,7 @@ class Trough:
         Calculates the values of insolation (in W/m^2) per time.
         These values are obtained from splines of the
         times and insolation data in the Insolation.txt file.
+
         Args:
             time (np.ndarray): times at which we want to calculate the Insolation.
         Output:
@@ -155,6 +158,7 @@ class Trough:
         Calculates the values of retreat of ice per time (mm/year).
         These values are obtained by evaluating self.ret_data_spline using
         the lag_model_t and time values.
+
         Args:
             lag_t (np.ndarray): lag at time
             time (np.ndarray): times at which we want to calculate the retreat
@@ -167,6 +171,7 @@ class Trough:
         """
         Obtains the x and y coordinates (in m) of the trough model as a
         function of time.
+
         Args:
             times (Optional[np.ndarray]): if ``None``, default to the
                 times of the observed solar insolation.
@@ -191,6 +196,7 @@ class Trough:
     def _L2_distance(x1, x2, y1, y2) -> Union[float, np.ndarray]:
         """
         The L2 (Eulerean) distance (squared) between two 2D vectors.
+
         Args:
             x1 (Union[float, np.ndarray]): x-coordinate of the first vector
             x2 (Union[float, np.ndarray]): x-coordinate of the second vector
@@ -209,6 +215,7 @@ class Trough:
         """
         Finds the coordinates of the nearest points between the model TMP
         and the data TMP.
+
         Args:
             x_data (np.ndarray): x-coordinates of the data
             y_data (np.ndarray): y-coordinatse of the data
@@ -230,10 +237,11 @@ class Trough:
             y_out[i] = y_model[ind]
         return x_out, y_out
 
-    def lnlikelihood(self, x_data: np.ndarray, y_data: np.ndarray):
+    def lnlikelihood(self, x_data: np.ndarray, y_data: np.ndarray) -> float:
         """
         Calculates the log-likelihood of the data given the model.
         Note that this is the natural log (ln).
+
         Args:
             x_data (np.ndarray): x-coordinates of the trough path
             y_data (np.ndarray): y-coordinates of the trough path

--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -2,7 +2,7 @@
 The trough model.
 """
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline as IUS
@@ -91,19 +91,22 @@ class Trough:
         # Compute splines of models of lag and retreat of ice per time
         self.compute_model_splines()
 
-    def set_model(self, acc_params, lag_params, errorbar):
+    def set_model(
+        self,
+        acc_params: Dict[str, float],
+        lag_params: Dict[str, float],
+        errorbar: float,
+    ) -> None:
         """
         Updates trough model with new accumulation and lag parameters.
         Model number is kept the same for both acumulation and lag.
 
         Args:
-            acc_params (list): Accumulation parameter(s) (same length
-                                     as current acumulation parameter(s)).
-            lag_params (list): Lag parameter(s) (same length
-                                     as current lag parameter(s)).
-            errorbar (float): Errorbar of the datapoints in pixels
-        Output:
-            None
+          acc_params (Dict[str, float]): Accumulation parameter(s) (same
+            length as current acumulation parameter(s)).
+          lag_params (Dict[str, float]): Lag parameter(s) (same length as
+            current lag parameter(s)).
+          errorbar (float): Errorbar of the datapoints in pixels
         """
         # Set the new errorbar
         self.errorbar = errorbar

--- a/mars_troughs/trough.py
+++ b/mars_troughs/trough.py
@@ -19,10 +19,10 @@ class Trough:
     that builds up over time, accesible as the :attr:`lagModel` attribute.
 
     Args:
-      acc_params (array like): model parameters for accumulation
+      acc_params (List[float]): model parameters for accumulation
+      lag_params (List[float]): model parameters for lag(t)
       acc_model_name (str): name of the accumulation model
         (linear, quadratic, etc)
-      lag_params (array like): model parameters for lag(t)
       lag_model_name (str): name of the lag(t) model (constant, linear, etc)
       errorbar (float, optional): errorbar of the datapoints in pixels; default=1
       angle (float, optional): south-facing slope angle in degrees. Default is 2.9.

--- a/test/test_trough.py
+++ b/test/test_trough.py
@@ -27,6 +27,21 @@ class TroughTest(TestCase):
         tr = self.get_trough_object()
         assert tr is not None
 
+    def test_set_model(self):
+        self.acc_params = [1e-6, 1e-11]
+        self.acc_model_name = "linear"
+        self.lag_params = [1]
+        self.lag_model_name = "constant"
+        tr = self.get_trough_object()
+        # Come up with new parameters
+        acc_params = {"intercept": 1.0, "slope": 2.0}
+        lag_params = {"constant": 33.0}
+        errorbar = 200.0
+        tr.set_model(acc_params, lag_params, errorbar)
+        assert tr.accuModel.parameters == acc_params
+        assert tr.lagModel.parameters == lag_params
+        assert tr.errorbar == errorbar
+
     def test_get_trajectory(self):
         tr = self.get_trough_object()
         x, y = tr.get_trajectory()


### PR DESCRIPTION
This short PR does some cleanup. Specifically it:

- removes the `acc_params` and `lag_params` attributes from the `Trough`, since their values already exist on the acc and lag models, respectively
- fixes the `set_model()` method so that the sub-models are **not** re-instantiated, just updated by setting the `parameters` attributes
- fixes the typing on `set_model()`
- tidies up some docstrings
- adds a unit test of the `Trough.set_model()` method, so that we know that the MCMC notebooks will work