### PR TITLE
Param names

### DIFF
--- a/mars_troughs/accumulation_model.py
+++ b/mars_troughs/accumulation_model.py
@@ -2,7 +2,7 @@
 Model for the accumulation rates.
 """
 from abc import abstractmethod
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline as IUS
@@ -106,8 +106,15 @@ class Linear_Insolation(TimeDependentAccumulationModel, LinearModel):
         intercept: float = 1e-6,
         slope: float = 1e-6,
     ):
+        self.acc_intercept=intercept
+        self.acc_slope=slope
+        
         super().__init__(times, insolations)
-        LinearModel.__init__(self, intercept, slope)
+        LinearModel.__init__(self, self.acc_intercept, self.acc_slope)
+        
+    @property
+    def parameter_names(self) -> List[str]:
+        return ["acc_intercept", "acc_slope"]
 
     def get_yt(self, time: np.ndarray):
         """
@@ -125,9 +132,9 @@ class Linear_Insolation(TimeDependentAccumulationModel, LinearModel):
         """
 
         return -(
-            self.intercept * time
+            self.acc_intercept * time
             + (
-                self.slope
+                self.acc_slope
                 * (self._int_var_data_spline(time) - self._int_var_data_spline(0))
             )
         )
@@ -158,8 +165,16 @@ class Quadratic_Insolation(TimeDependentAccumulationModel, QuadModel):
         linearCoeff: float = 1e-6,
         quadCoeff: float = 1e-6,
     ):
+        self.acc_intercept= intercept
+        self.acc_linearCoeff= linearCoeff
+        self.acc_quadCoeff= quadCoeff
+        
         super().__init__(times, insolation)
-        QuadModel.__init__(self, intercept, linearCoeff, quadCoeff)
+        QuadModel.__init__(self, self.acc_intercept, self.acc_linearCoeff, self.acc_quadCoeff)
+        
+    @property
+    def parameter_names(self) -> List[str]:
+        return ["acc_intercept", "acc_linearCoeff", "acc_quadCoeff"]
 
     def get_yt(self, time: np.ndarray):
         """
@@ -176,11 +191,11 @@ class Quadratic_Insolation(TimeDependentAccumulationModel, QuadModel):
 
         """
         return -(
-            self.intercept * time
+            self.acc_intercept * time
             + (
-                self.linearCoeff
+                self.acc_linearCoeff
                 * (self._int_var_data_spline(time) - self._int_var_data_spline(0))
-                + self.quadCoeff
+                + self.acc_quadCoeff
                 * (
                     self._int_var2_data_spline(time)
                     - self._int_var2_data_spline(0)
@@ -197,9 +212,15 @@ class Linear_Obliquity(TimeDependentAccumulationModel, LinearModel):
         intercept: float = 1.0,
         slope: float = 1.0,
     ):
+        self.acc_intercept=intercept
+        self.acc_slope=slope
 
-        LinearModel.__init__(self, intercept, slope)
+        LinearModel.__init__(self, self.acc_intercept, self.acc_slope)
         super().__init__(obl_times, obliquity)
+        
+    @property
+    def parameter_names(self) -> List[str]:
+        return ["acc_intercept", "acc_slope"]
 
     def get_yt(self, time: np.ndarray):
         """
@@ -217,9 +238,9 @@ class Linear_Obliquity(TimeDependentAccumulationModel, LinearModel):
         """
 
         return -(
-            self.intercept * time
+            self.acc_intercept * time
             + (
-                self.slope
+                self.acc_slope
                 * (self._int_var_data_spline(time) - self._int_var_data_spline(0))
             )
         )

--- a/mars_troughs/generic_model.py
+++ b/mars_troughs/generic_model.py
@@ -7,8 +7,6 @@ Created on Thu May  6 10:37:51 2021
 
 Linear model for both accumulation and lag
 """
-from typing import List
-
 import numpy as np
 
 from mars_troughs.model import Model
@@ -28,11 +26,6 @@ class ConstantModel(Model):
 
     def __init__(self, constant: float = 1.0):
         self.constant = constant
-
-    @property
-    def parameter_names(self) -> List[str]:
-        """Returns ``["constant"]``"""
-        return ["constant"]
 
     def eval(self, x) -> float:
         """Returns the value of :attr:`constant`."""
@@ -54,10 +47,6 @@ class LinearModel(Model):
     def __init__(self, intercept: float = 1.0, slope: float = 1.0):
         self.intercept = intercept
         self.slope = slope
-
-    @property
-    def parameter_names(self) -> List[str]:
-        return ["intercept", "slope"]
 
     def eval(self, x) -> float:
         return self.intercept + x * self.slope
@@ -84,10 +73,6 @@ class QuadModel(Model):
         self.intercept = intercept
         self.linearCoeff = linearCoeff
         self.quadCoeff = quadCoeff
-
-    @property
-    def parameter_names(self) -> List[str]:
-        return ["intercept", "linearCoeff", "quadCoeff"]
 
     def eval(self, x) -> float:
         p = [self.intercept, self.linearCoeff, self.quadCoeff]

--- a/mars_troughs/lag_model.py
+++ b/mars_troughs/lag_model.py
@@ -1,7 +1,7 @@
 """
 Models for the lag as a function of time.
 """
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 
@@ -42,8 +42,15 @@ class ConstantLag(LagModel, ConstantModel):
         self,
         constant: float = 1e-6,
     ):
+        self.lag_constant=constant
+        
         super().__init__()  # note: `super` maps to the LagModel parent class
-        ConstantModel.__init__(self, constant=constant)
+        ConstantModel.__init__(self, constant=self.lag_constant)
+        
+    @property
+    def parameter_names(self) -> List[str]:
+        """Returns ``["constant"]``"""
+        return ["lag_constant"]
 
 
 class LinearLag(LagModel, LinearModel):
@@ -63,8 +70,15 @@ class LinearLag(LagModel, LinearModel):
         intercept: float = 1e-6,
         slope: float = 1e-6,
     ):
+        self.lag_intercept=intercept
+        self.lag_slope=slope
+        
         super().__init__()
-        LinearModel.__init__(self, intercept=intercept, slope=slope)
+        LinearModel.__init__(self, intercept=self.lag_intercept, slope=self.lag_slope)
+        
+    @property
+    def parameter_names(self) -> List[str]:
+        return ["lag_intercept", "lag_slope"]
 
 
 LAG_MODEL_MAP: Dict[str, Model] = {

--- a/test/test_accumulation_model.py
+++ b/test/test_accumulation_model.py
@@ -23,7 +23,7 @@ class LinearAccumulationTest(TestCase):
         insolation = np.sin(np.radians(np.linspace(0, 360, 100)))
         times = np.linspace(0, 100, 100)
         model = Linear_Insolation(times, insolation)
-        assert model.parameter_names == ["intercept", "slope"]
+        assert model.parameter_names == ["acc_intercept", "acc_slope"]
 
     def test_constant(self):
         insolation = np.sin(np.radians(np.linspace(0, 360, 100)))
@@ -95,7 +95,7 @@ class QuadraticAccumulationTest(TestCase):
         insolation = np.sin(np.radians(np.linspace(0, 360, 100)))
         times = np.linspace(0, 100, 100)
         model = Quadratic_Insolation(times, insolation)
-        assert model.parameter_names == ["intercept", "linearCoeff", "quadCoeff"]
+        assert model.parameter_names == ["acc_intercept", "acc_linearCoeff", "acc_quadCoeff"]
 
     def test_constant(self):
         insolation = np.sin(np.radians(np.linspace(0, 360, 100)))
@@ -189,7 +189,7 @@ class ObliquityLinearAccumulationTest(TestCase):
         obliquity = np.sin(np.radians(np.linspace(0, 360, 100)))
         times = np.linspace(0, 100, 100)
         model = Linear_Obliquity(times, obliquity)
-        assert model.parameter_names == ["intercept", "slope"]
+        assert model.parameter_names == ["acc_intercept", "acc_slope"]
 
     def test_constant(self):
         obliquity = np.sin(np.radians(np.linspace(0, 360, 100)))

--- a/test/test_lag_model.py
+++ b/test/test_lag_model.py
@@ -17,7 +17,7 @@ class ConstantLagTest(TestCase):
 
     def test_parameter_names(self):
         model = ConstantLag()
-        assert model.parameter_names == ["constant"]
+        assert model.parameter_names == ["lag_constant"]
 
     def test_constant(self):
         model1 = ConstantLag()
@@ -43,7 +43,7 @@ class LinearLagTest(TestCase):
 
     def test_parameter_names(self):
         model = LinearLag()
-        assert model.parameter_names == ["intercept", "slope"]
+        assert model.parameter_names == ["lag_intercept", "lag_slope"]
 
     def test_constant(self):
         model1 = LinearLag()

--- a/test/test_trough.py
+++ b/test/test_trough.py
@@ -36,8 +36,8 @@ class TroughTest(TestCase):
         # Trajectory predictions
         x1, y1 = tr.get_trajectory()
         # Come up with new parameters
-        acc_params = {"intercept": 1.0, "slope": 2.0}
-        lag_params = {"constant": 33.0}
+        acc_params = {"acc_intercept": 1.0, "acc_slope": 2.0}
+        lag_params = {"lag_constant": 33.0}
         errorbar = 200.0
         tr.set_model(acc_params, lag_params, errorbar)
         assert tr.accuModel.parameters == acc_params
@@ -103,8 +103,8 @@ class TroughTest(TestCase):
         self.lag_model_name = "constant"
         tr = self.get_trough_object()
         # Come up with new parameters
-        acc_params = {"intercept": 1.0, "slope": 2.0}
-        lag_params = {"constant": 33.0}
+        acc_params = {"acc_intercept": 1.0, "acc_slope": 2.0}
+        lag_params = {"lag_constant": 33.0}
         errorbar = 200.0
         tr.set_model(acc_params, lag_params, errorbar)
         assert tr.accuModel.parameters == acc_params


### PR DESCRIPTION
-Moved the parameter_names property from the generic model classes to the corresponding accumulation and lag submodels
-Modified the names of the parameters to include lag and acc. For example: intercept to acc_intercept and lag_intercept
-Modified tests with updated parameter names